### PR TITLE
refactor: use common method to launch ansible runner

### DIFF
--- a/ansible/executors/base_executor.py
+++ b/ansible/executors/base_executor.py
@@ -5,15 +5,16 @@ import logging
 
 from typing import List, Optional
 
+import ansible_runner
 from ansible_runner import Runner, AnsibleRunnerException
 from ansible.exceptions import AnsibleExecuteError, AnsibleNoHostsMatched
 
 logger = logging.getLogger('ansible_deploy')
 
 
-class AbstractAnsibleExecutor:
+class BaseAnsibleExecutor:
     """
-    Class contains methods for launching `runner` in various ways
+    Class contains logic for launching and analysing `runner` in synchronous way
     """
     def __init__(self, host_pattern: str, private_data_dir: str, verbosity: int):
         self._host_pattern = host_pattern
@@ -30,12 +31,25 @@ class AbstractAnsibleExecutor:
         """ Successful result of ansible task execution """
         return 0
 
-    def _add_common_ansible_params(self, params_to_execute: dict) -> None:
+    def _execute_ansible_runner(self, params_to_execute: dict) -> Runner:
+        """        (Synchronously!)
+        Entry point for ansible-runner execution
+
+        Sets several params (such as verbosity and 'private data dir') before execution
+
+        Args:
+            params_to_execute: params for ansible-runner (for more info see `ansible-runner/interface.py`)
+        Returns:
+            ansible runner object after execution
+        """
         # set ansible verbosity level
         params_to_execute['verbosity'] = self._verbosity
 
         # directory where ansible artifacts will be stored
         params_to_execute['private_data_dir'] = self._private_data_dir
+
+        runner = ansible_runner.run(**params_to_execute)
+        return runner
 
     def _check_runner_execution(self, runner: Runner, host_pattern: str, executed_entity: str) -> None:
         """

--- a/ansible/executors/module_executor.py
+++ b/ansible/executors/module_executor.py
@@ -5,7 +5,6 @@ import asyncio
 import logging
 from typing import Optional
 
-import ansible_runner
 from ansible_runner import Runner
 
 from ansible.decorators import error_log_handler

--- a/ansible/executors/module_executor.py
+++ b/ansible/executors/module_executor.py
@@ -9,20 +9,19 @@ import ansible_runner
 from ansible_runner import Runner
 
 from ansible.decorators import error_log_handler
-from ansible.executors.abstract_executor import AbstractAnsibleExecutor
+from ansible.executors.base_executor import BaseAnsibleExecutor
 
 logger = logging.getLogger('ansible_deploy')
 
 
-class AnsibleModuleExecutor(AbstractAnsibleExecutor):
+class AnsibleModuleExecutor(BaseAnsibleExecutor):
     """ Class is responsible for executing ad-hoc commands """
 
     def __init__(self, host_pattern: str, private_data_dir: str, verbosity: int):
         super().__init__(host_pattern=host_pattern, private_data_dir=private_data_dir, verbosity=verbosity)
 
     def _run_ad_hoc_command(self, params_to_execute: dict) -> Runner:
-        """
-        (Synchronously!)
+        """        (Synchronously!)
         Launches ansible runner with passed parameters as an `ad-hoc` command
 
         Args:
@@ -36,12 +35,9 @@ class AnsibleModuleExecutor(AbstractAnsibleExecutor):
         logger.info("Initiate '%s' module to execute", module_name)
 
         logger.debug("Collected next params for ansible runner: %s", params_to_execute)
-        self._add_common_ansible_params(params_to_execute)
+        runner = self._execute_ansible_runner(params_to_execute)
 
-        # entry point of module execution
-        runner = ansible_runner.run(**params_to_execute)
         logger.debug("Stats of '%s' module execution: %s", module_name, runner.stats)
-
         self._check_runner_execution(runner,
                                      host_pattern=params_to_execute['host_pattern'],
                                      executed_entity=module_name)

--- a/ansible/executors/playbook_executor.py
+++ b/ansible/executors/playbook_executor.py
@@ -11,7 +11,7 @@ from ansible_runner import Runner
 
 from ansible import ansible_const
 from ansible.decorators import error_log_handler
-from ansible.executors.abstract_executor import AbstractAnsibleExecutor
+from ansible.executors.base_executor import BaseAnsibleExecutor
 
 logger = logging.getLogger('ansible_deploy')
 
@@ -35,15 +35,14 @@ class PermittedPlaybooksMixin:
         return os.path.join(self._playbook_location_dir, 'file_create.yml')
 
 
-class AnsiblePlaybookExecutor(AbstractAnsibleExecutor, PermittedPlaybooksMixin):
+class AnsiblePlaybookExecutor(BaseAnsibleExecutor, PermittedPlaybooksMixin):
     """  Class is responsible for executing playbooks """
 
     def __init__(self, host_pattern: str, private_data_dir: str, verbosity: int):
         super().__init__(host_pattern=host_pattern, private_data_dir=private_data_dir, verbosity=verbosity)
 
     def _run_playbook(self, params_to_execute: dict) -> Runner:
-        """
-        (Synchronously!)
+        """        (Synchronously!)
         Launches ansible runner with passed parameters as an `ansible-playbook` command
 
         Args:
@@ -52,17 +51,14 @@ class AnsiblePlaybookExecutor(AbstractAnsibleExecutor, PermittedPlaybooksMixin):
         Returns:
             ansible runner object after execution
         """
-        assert 'playbook' in params_to_execute, "Argument 'playbook' must be defined for a playbook execution"
+        assert 'playbook' in params_to_execute, "Argument 'playbook' must be defined for a ansible-playbook execution"
         playbook_name = os.path.basename(params_to_execute['playbook'])
         logger.info("Initiate '%s' playbook to execute", playbook_name)
 
         logger.debug("Collected next params for ansible runner: %s", params_to_execute)
-        self._add_common_ansible_params(params_to_execute)
+        runner = self._execute_ansible_runner(params_to_execute)
 
-        # entry point of playbook execution
-        runner = ansible_runner.run(**params_to_execute)
         logger.info("Stats of '%s' playbook execution: %s", playbook_name, runner.stats)
-
         self._check_runner_execution(runner,
                                      host_pattern=params_to_execute['extravars'][ansible_const.HOST_PATTERN],
                                      executed_entity=playbook_name)

--- a/ansible/executors/playbook_executor.py
+++ b/ansible/executors/playbook_executor.py
@@ -6,7 +6,6 @@ import logging
 import os
 from pathlib import Path
 
-import ansible_runner
 from ansible_runner import Runner
 
 from ansible import ansible_const


### PR DESCRIPTION
keep 'dry' code and change class assignment for the 'base ansible executor'